### PR TITLE
Fixing undeclared function errors

### DIFF
--- a/nanocolor.c
+++ b/nanocolor.c
@@ -23,6 +23,7 @@
 //
 
 #include "nanocolor.h"
+#include "nanocolorProcess.h"
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>

--- a/nanocolor.c
+++ b/nanocolor.c
@@ -23,7 +23,7 @@
 //
 
 #include "nanocolor.h"
-#include "nanocolorProcess.h"
+#include "nanocolorProcessing.h"
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>

--- a/nanocolorUtils.c
+++ b/nanocolorUtils.c
@@ -23,6 +23,7 @@
 //
 
 #include "nanocolorUtils.h"
+#include "nanocolorProcessing.h"
 #include <math.h>
 
 /*


### PR DESCRIPTION
Moving the processing function declarations into `nanocolorProcessing.h` has broken compilation for me. When compiling `nanocolor.c` it complains that the functions have not been declared (which they haven't!). Adding `#include "nanocolorProcessing.h"` in `nanocolor.c` right after the `#include "nanocolor.h"` fixes this for me.